### PR TITLE
Use platform-independent commands in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -77,8 +77,8 @@ install:
 # Remove temporary files
 [group('lifecycle')]
 clean:
-    rm -rf .venv .pytest_cache .mypy_cache .ruff_cache .coverage htmlcov
-    find . -type d -name "__pycache__" -exec rm -r {} +
+    uv run python -c "import shutil; shutil.rmtree('.venv', ignore_errors=True)"
+    uvx pyclean . -d all
 
 # Recreate project virtualenv from nothing
 [group('lifecycle')]


### PR DESCRIPTION
As explained in your video, we don't want to use a Makefile because we'd lose out on Windows users; and even on macOS, shell commands may behave differently than on GNU/Linux.

We can achieve the same result with Python. For a more controlled, idiomatic cleanup there's PyClean. – Full disclosure: I'm its author, but similar packages exist if you prefer others.

Note that PyClean could also remove the .venv folder (using the -e option), but how well that works depends on the shell (e.g. Bash works better than Zsh) because order matters.